### PR TITLE
added ability to update an existing scope

### DIFF
--- a/docs/resources/scope.md
+++ b/docs/resources/scope.md
@@ -6,54 +6,56 @@ description: |-
   Resource for creating a scope in Secure Workload
   Example
   An example is shown below:
-  ```hcl
-  resource "secureworkloadscope" "scope" {
-      shortname = "Terraform-created-scope"
-      subtype = "DNSSERVERS"
-      shortquery = file("${path.module}/queryfile.json")
-       parentappscopeid = data.secureworkloadscope.scope.id
-  }
-  resource "secureworkloadscope" "scope2" {
-      shortname = "Terraform-created-scope2"
-      query = <<EOF
-                  {
-                   "type":"subnet",
-                   "field": "ip",
-                   "value": "10.0.1.0/24"
-                   }
-              EOF
-      subtype = "GENERIC"
-       parentappscopeid = data.secureworkloadscope.scope.id
+  
+  resource "secureworkload_scope" "scope" {
+      short_name = "Terraform-created-scope"
+      sub_type = "DNS_SERVERS"
+      short_query = file("${path.module}/query_file.json") 
+  	 parent_app_scope_id = data.secureworkload_scope.scope.id
   }
   
-  Example of **query_file.json**
-  json
-  {    "type": "or",
-      "filters": [
-        {
-      "type": "and",
-          "filters": [
-            {
-              "type": "contains",
-              "field": "userorchestratorsystem/name",
-              "value": "Random"
-            },
-            {
-              "type": "eq",
-              "field": "ip",
-              "value": "10.0.1.1"
-            }
-          ]
-        },
-        {
-          "type": "gt",
-          "field": "hosttagscvss",
-          "value": 2
-        }
-      ]
+  resource "secureworkload_scope" "scope2" {
+      short_name = "Terraform-created-scope2"
+      short_query = <<EOF
+                  { 
+          		 "type":"subnet",
+          		 "field": "ip",
+          		 "value": "10.0.1.0/24"
+          		 }
+          	EOF
+      sub_type = "GENERIC"
+  	 parent_app_scope_id = data.secureworkload_scope.scope.id
+  }
+  
+  Example of query_file.json
+  
+  {	
+  	"type": "or",
+  	"filters": [ 
+  	  {
+  	"type": "and",
+  		"filters": [ 
+  		  { 
+  			"type": "contains",
+  			"field": "user_orchestrator_system/name",
+  			"value": "Random"
+  		  },
+  		  {
+  			"type": "eq",
+  			"field": "ip",
+  			"value": "10.0.1.1"
+  		  }
+  		]
+  	  },
+  	  {
+  		"type": "gt",
+  		"field": "host_tags_cvss",
+  		"value": 2
+  	  }
+  	]
     }
-  ``
-  **Note:** If creating multiple resources for scope during a singleterraform apply, you may have to usedependson` to chain the resources so that terraform creates it in the same order that you intended.
+  
+  Note: If creating multiple resources for scope during a single terraform apply, you may have to use depends_on to chain the resources so that terraform creates it in the same order that you intended.
 ---
 
 # secureworkload_scope (Resource)
@@ -72,7 +74,7 @@ resource "secureworkload_scope" "scope" {
 
 resource "secureworkload_scope" "scope2" {
     short_name = "Terraform-created-scope2"
-    query = <<EOF
+    short_query = <<EOF
                 { 
         		 "type":"subnet",
         		 "field": "ip",
@@ -125,6 +127,7 @@ Example of **query_file.json**
 
 ### Optional
 
+- `commit_on_update` (Boolean) Whether to commit the scope changes on update.
 - `description` (String) User-specified description of the scope.
 - `policy_priority` (Number) Used to sort application priorities; default is last.
 - `short_query` (String) JSON object representation of an inventory filter query. The query shown in the above example is 'orchestrator_system/name containes Random and Address = 10.0.1.1 or CVE Score v3 >2'.Operator can any of the following: [and, or, eq, subnet, contains, regex, gt, gte, lt, lte, in, range, ranges, not, all, none]
@@ -142,5 +145,3 @@ Example of **query_file.json**
 - `short_priority` (Number) Used to sort application priorities; default is last.
 - `updated_at` (Number) Unix Epoch timestamp when scope was last updated.
 - `vrf_id` (Number) ID of the VRF to which scope belongs.
-
-

--- a/secureworkload/resource_secureworkload_scope.go
+++ b/secureworkload/resource_secureworkload_scope.go
@@ -85,7 +85,7 @@ func resourceSecureWorkloadScope() *schema.Resource {
 			"sub_type": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "User-specified sub type for the scope.",
 			},
 			"description": {
@@ -111,7 +111,7 @@ func resourceSecureWorkloadScope() *schema.Resource {
 			"short_query": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				ForceNew:    true,
+				ForceNew:    false,
 				Description: "JSON object representation of an inventory filter query. The query shown in the above example is 'orchestrator_system/name containes Random and Address = 10.0.1.1 or CVE Score v3 >2'.Operator can any of the following: [and, or, eq, subnet, contains, regex, gt, gte, lt, lte, in, range, ranges, not, all, none] ",
 			},
 			"name": {
@@ -216,16 +216,15 @@ func resourceSecureWorkloadScopeRead(d *schema.ResourceData, meta interface{}) e
 
 func resourceSecureWorkloadScopeUpdate(d *schema.ResourceData, meta interface{}) error {
 	client := meta.(Client)
-	client.DeleteScope(d.Id())
-	createScopeParams := CreateScopeRequest{
-		ShortName:        d.Get("short_name").(string),
-		Description:      d.Get("description").(string),
-		ParentAppScopeId: d.Get("parent_app_scope_id").(string),
-		ShortQuery:       []byte(d.Get("short_query").(string)),
-		SubType:          d.Get("sub_type").(string),
-		PolicyPriority:   d.Get("policy_priority").(int),
+	updateScopeParams := UpdateScopeRequest{
+		SubType:        d.Get("sub_type").(string),
+		Description:    d.Get("description").(string),
+		ShortQuery:     []byte(d.Get("short_query").(string)),
+		PolicyPriority: d.Get("policy_priority").(int),
 	}
-	scope, err := client.CreateScope(createScopeParams)
+
+	scope, err := client.UpdateScope(updateScopeParams, d.Id())
+
 	if err != nil {
 		return err
 	}

--- a/secureworkload/resource_secureworkload_scope.go
+++ b/secureworkload/resource_secureworkload_scope.go
@@ -161,6 +161,12 @@ func resourceSecureWorkloadScope() *schema.Resource {
 				Computed:    true,
 				Description: "Unix Epoch timestamp when scope was last updated.",
 			},
+			"commit_on_update": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Whether to commit the scope changes on update.",
+			},
 		},
 	}
 }
@@ -228,6 +234,21 @@ func resourceSecureWorkloadScopeUpdate(d *schema.ResourceData, meta interface{})
 	if err != nil {
 		return err
 	}
+	if d.Get("commit_on_update").(bool) {
+		commitDirtyScopeParams := CommitDirtyScopeRequest{
+			ParentAppScopeId: d.Get("root_app_scope_id").(string),
+			Sync:             true,
+		}
+
+		scope, err := client.CommitDirtyScope(commitDirtyScopeParams)
+
+		if err != nil {
+			return err
+		}
+
+		d.Set("sync", scope.CommitDirty)
+	}
+	d.Set("short_query", scope.ShortQuery)
 	d.Set("description", scope.Description)
 	d.Set("policy_priority", scope.PolicyPriority)
 	d.SetId(scope.Id)

--- a/secureworkload/secureworkload_scopes.go
+++ b/secureworkload/secureworkload_scopes.go
@@ -89,6 +89,18 @@ type CreateScopeRequest struct {
 	PolicyPriority int `json:"policy_priority,omitempty"`
 }
 
+// UpdateScopeRequest wraps parameters for making a request
+// to update a scope
+type UpdateScopeRequest struct {
+	SubType string `json:"sub_type,omitempty"`
+	// User-specified description of the scope.
+	Description string `json:"description"`
+	// Filter (or match criteria) associated with the scope.
+	ShortQuery json.RawMessage `json:"short_query,omitempty"`
+	// Used to sort application priorities; default is last.
+	PolicyPriority int `json:"policy_priority,omitempty"`
+}
+
 func (c Client) GetScopeByParam(getUrl string) ([]GetScope, error) {
 	var scope []GetScope
 	url := c.Config.APIURL + ScopesAPIV1BasePath + getUrl
@@ -106,6 +118,19 @@ func (c Client) CreateScope(params CreateScopeRequest) (Scope, error) {
 	var scope Scope
 	url := c.Config.APIURL + ScopesAPIV1BasePath
 	request, err := signer.CreateJSONRequest(http.MethodPost, url, params)
+	if err != nil {
+		return scope, err
+	}
+	err = c.Do(request, &scope)
+	return scope, err
+}
+
+// UpdateScope creates a scope with the specified params,
+// returning the created scope and error (if any).
+func (c Client) UpdateScope(params UpdateScopeRequest, scopeId string) (Scope, error) {
+	var scope Scope
+	url := c.Config.APIURL + ScopesAPIV1BasePath + fmt.Sprintf("/%s", scopeId)
+	request, err := signer.CreateJSONRequest(http.MethodPut, url, params)
 	if err != nil {
 		return scope, err
 	}

--- a/secureworkload/secureworkload_scopes.go
+++ b/secureworkload/secureworkload_scopes.go
@@ -10,7 +10,8 @@ import (
 )
 
 var (
-	ScopesAPIV1BasePath = fmt.Sprintf("%s/app_scopes", SecureWorkloadAPIV1BasePath)
+	ScopesAPIV1BasePath  = fmt.Sprintf("%s/app_scopes", SecureWorkloadAPIV1BasePath)
+	CommitDirtyAPIV1Path = fmt.Sprintf("%s/commit_dirty", ScopesAPIV1BasePath)
 )
 
 // ScopeQuery wraps a Filter (or match criteria) associated
@@ -63,6 +64,7 @@ type Scope struct {
 	ChildAppScopeIds []string   `json:"child_app_scope_ids"`
 	CreatedAt        int64      `json:"created_at"`
 	UpdatedAt        int64      `json:"updated_at"`
+	CommitDirty      bool       `json:"sync"`
 }
 
 // ShortQuery wraps a query used as part of the request to create a scope
@@ -99,6 +101,11 @@ type UpdateScopeRequest struct {
 	ShortQuery json.RawMessage `json:"short_query,omitempty"`
 	// Used to sort application priorities; default is last.
 	PolicyPriority int `json:"policy_priority,omitempty"`
+}
+
+type CommitDirtyScopeRequest struct {
+	ParentAppScopeId string `json:"root_app_scope_id"`
+	Sync             bool   `json:"sync"`
 }
 
 func (c Client) GetScopeByParam(getUrl string) ([]GetScope, error) {
@@ -173,4 +180,17 @@ func (c Client) ListScopes() ([]Scope, error) {
 	}
 	err = c.Do(request, &scopes)
 	return scopes, err
+}
+
+// CommitDirtyScope allows for dirty scopes to be
+// committed to the scope tree immediately
+func (c Client) CommitDirtyScope(params CommitDirtyScopeRequest) (Scope, error) {
+	var scope Scope
+	url := c.Config.APIURL + CommitDirtyAPIV1Path
+	request, err := signer.CreateJSONRequest(http.MethodPost, url, params)
+	if err != nil {
+		return scope, err
+	}
+	err = c.Do(request, &scope)
+	return scope, err
 }


### PR DESCRIPTION
Currently, the scope resource will delete and recreate an entire scope in CSW rather than just using the PUT method to update criteria that can be updated in place. 

Without this update in place, you would lose all scoped data if you needed to adjust the subtype or the match query for the scope.